### PR TITLE
Modernize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 from setuptools import setup, find_packages
 

--- a/tappio/__init__.py
+++ b/tappio/__init__.py
@@ -19,6 +19,8 @@
 #
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 __all__ = ['load', 'dump', 'loads', 'dumps', 'loadf', 'dumpf']
 
 

--- a/tappio/lexer.py
+++ b/tappio/lexer.py
@@ -25,6 +25,7 @@ A lexer for the Tappio file format.
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from six.moves import range
+from .unicode import unicode
 TOKENS = (
     'brace_open',
     'brace_close',
@@ -43,7 +44,7 @@ def build_set(*args):
                 s.add(chr(k))
         else:
             for ch in arg:
-                assert type(ch) in (str, str)
+                assert type(ch) in (str, unicode)
                 assert len(ch) == 1
                 s.add(ch)
 

--- a/tappio/lexer.py
+++ b/tappio/lexer.py
@@ -64,11 +64,11 @@ class Token(object):
         value = repr(getattr(self, "value", None))
         return "<Token: {0} {1}>".format(token_type, value)
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if isinstance(other, Token):
-            return cmp((self.token_type, self.value), (other.token_type, other.value))
+            return (self.token_type, self.value) == (other.token_type, other.value)
         elif (isinstance(other, list) or isinstance(other, tuple)) and len(other) == 2:
-            return cmp((self.token_type, self.value), other)
+            return (self.token_type, self.value) == tuple(other)
         else:
             raise TypeError("cannot compare Token to {0}".format(repr(type(other))))
 

--- a/tappio/lexer.py
+++ b/tappio/lexer.py
@@ -22,6 +22,9 @@
 A lexer for the Tappio file format.
 """
 
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from six.moves import range
 TOKENS = (
     'brace_open',
     'brace_close',
@@ -40,7 +43,7 @@ def build_set(*args):
                 s.add(chr(k))
         else:
             for ch in arg:
-                assert type(ch) in (str, unicode)
+                assert type(ch) in (str, str)
                 assert len(ch) == 1
                 s.add(ch)
 

--- a/tappio/models.py
+++ b/tappio/models.py
@@ -30,6 +30,8 @@ Document 1 --> * Event 1 --> * Entry 1 --> Account
 """
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import date
 
 import voitto

--- a/tappio/parser.py
+++ b/tappio/parser.py
@@ -19,6 +19,8 @@
 #
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import date
 
 from .models import Document, Account, Event, Entry
@@ -47,7 +49,7 @@ class Parser(object):
             self.next_token = None
         else:
             try:
-                token = self.token_iterator.next()
+                token = next(self.token_iterator)
             except StopIteration:
                 self.error("end of file while expecting {0}", expected_type)
 
@@ -64,7 +66,7 @@ class Parser(object):
             token = self.next_token
         else:
             try:
-                token = self.token_iterator.next()
+                token = next(self.token_iterator)
                 self.next_token = token
             except StopIteration:
                 token = None

--- a/tappio/scripts/extract.py
+++ b/tappio/scripts/extract.py
@@ -2,12 +2,15 @@
 # encoding: utf-8
 # vim: shiftwidth=4 expandtab
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import date, datetime
 
 from tappio import loadf, dumpf
 from tappio.models import Event, Entry
 
 from .print_earnings import collect_earnings
+import six
 
 
 BALANCES_DEFAULT_DESCRIPTION = "Tilinavaukset"
@@ -41,7 +44,7 @@ def balances(document, at_date=None, description=BALANCES_DEFAULT_DESCRIPTION,
     balances = collect_earnings([i for i in document.events if i.date < at_date])
     balance_accounts = get_balance_accounts(document.accounts)
 
-    for account_number, cents in balances.iteritems():
+    for account_number, cents in six.iteritems(balances):
         if account_number in balance_accounts:
             result.entries.append(Entry(account_number=account_number, cents=cents))
 

--- a/tappio/scripts/graph.py
+++ b/tappio/scripts/graph.py
@@ -5,6 +5,8 @@
 # TODO: Escape stuff
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import sys
 from contextlib import contextmanager
 

--- a/tappio/scripts/indent.py
+++ b/tappio/scripts/indent.py
@@ -2,6 +2,8 @@
 # encoding: utf-8
 # vim: shiftwidth=4 expandtab
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from tappio import loadf, dumpf
 
 def indent(input_filename=None, output_filename=None):

--- a/tappio/scripts/merge.py
+++ b/tappio/scripts/merge.py
@@ -3,8 +3,11 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from tappio import loadf, dumpf
 from tappio.models import Document
+from functools import reduce
 
 
 def combine_accounts(earliers, laters):

--- a/tappio/scripts/missing_accounts.py
+++ b/tappio/scripts/missing_accounts.py
@@ -3,8 +3,13 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 from collections import defaultdict
 from tappio import loadf, dumpf
+import six
+from six.moves import map
 
 
 ONLY=True
@@ -33,22 +38,22 @@ def missing_accounts(*input_filenames):
     flat_accounts = dict((filename, flatten_accounts(document.accounts)) for (filename, document) in documents)
 
     all_accounts = dict()
-    map(all_accounts.update, flat_accounts.itervalues())
+    list(map(all_accounts.update, six.itervalues(flat_accounts)))
     
     havity = defaultdict(set)
-    for account_num, account in all_accounts.iteritems():
-        for filename, accounts in flat_accounts.iteritems():
+    for account_num, account in six.iteritems(all_accounts):
+        for filename, accounts in six.iteritems(flat_accounts):
             if account_num in accounts:
                 havity[account_num].add(filename)
 
-    for account_num, filenames in havity.iteritems():
+    for account_num, filenames in six.iteritems(havity):
         fmt_filenames = " ".join(filenames)
 
         if filenames == input_filenames:
             if not ONLY:
-                print "{account_num}: ALL  {fmt_filenames}".format(**locals())
+                print("{account_num}: ALL  {fmt_filenames}".format(**locals()))
         else:
-            print "{account_num}: ONLY {fmt_filenames}".format(**locals())
+            print("{account_num}: ONLY {fmt_filenames}".format(**locals()))
             
 
 def main():

--- a/tappio/scripts/move_entries.py
+++ b/tappio/scripts/move_entries.py
@@ -3,6 +3,8 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from tappio import loadf, dumpf
 
 

--- a/tappio/scripts/print_accounts.py
+++ b/tappio/scripts/print_accounts.py
@@ -3,15 +3,18 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 from tappio import loadf
 
 
 def print_accounts(accounts, indent=0, indent_increment=2):
     for account in accounts:
         if account.number is not None:
-            print "%s%d %s" % (" "*indent, account.number, account.name)
+            print("%s%d %s" % (" "*indent, account.number, account.name))
         else:
-            print "%s%s" % (" "*indent, account.name)
+            print("%s%s" % (" "*indent, account.name))
         print_accounts(account.subaccounts, indent=indent+indent_increment)
 
 

--- a/tappio/scripts/print_earnings.py
+++ b/tappio/scripts/print_earnings.py
@@ -3,6 +3,8 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import sys
 
 from csv import writer

--- a/tappio/scripts/renumber.py
+++ b/tappio/scripts/renumber.py
@@ -3,6 +3,8 @@
 # vim: shiftwidth=4 expandtab
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from tappio import loadf, dumpf
 
 

--- a/tappio/unicode.py
+++ b/tappio/unicode.py
@@ -1,0 +1,5 @@
+import sys
+if sys.version_info.major == 3:
+    unicode = str
+else:
+    unicode = unicode

--- a/tappio/writer.py
+++ b/tappio/writer.py
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 import sys
 

--- a/tappio/writer.py
+++ b/tappio/writer.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from .unicode import unicode
 import datetime
 import sys
 
@@ -47,7 +48,7 @@ class Writer(object):
         for token in tokens:
             if self.should_put_space_between(self.prev_token, token):
                 self.stream.write(" ")
-            self.stream.write(str(token))
+            self.stream.write(unicode(token))
 
             self.prev_token = token
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,6 +24,8 @@ Testing related helpers.
 """
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from functools import wraps
 
 from nose.plugins.skip import SkipTest

--- a/tests/script_import_test.py
+++ b/tests/script_import_test.py
@@ -20,6 +20,8 @@
 #
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from StringIO import StringIO
 from pkg_resources import load_entry_point
 

--- a/tests/script_import_test.py
+++ b/tests/script_import_test.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from StringIO import StringIO
+from io import StringIO
 from pkg_resources import load_entry_point
 
 from nose.tools import *

--- a/tests/tappio_test.py
+++ b/tests/tappio_test.py
@@ -20,6 +20,9 @@
 #
 
 
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 from StringIO import StringIO
 
 from nose.tools import *
@@ -170,9 +173,9 @@ def parser_single(input):
     lex = Lexer()
 
     try:
-        print Parser(lex.lex_string(input)).parse_document()
-    except ParserError, e:
-        print lex.linenum, lex.chnum
+        print(Parser(lex.lex_string(input)).parse_document())
+    except ParserError as e:
+        print(lex.linenum, lex.chnum)
         raise e
 
 

--- a/tests/tappio_test.py
+++ b/tests/tappio_test.py
@@ -23,7 +23,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-from StringIO import StringIO
+from io import StringIO
 
 from nose.tools import *
 

--- a/voitto/__init__.py
+++ b/voitto/__init__.py
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution('voitto').version

--- a/voitto/helpers/io.py
+++ b/voitto/helpers/io.py
@@ -24,6 +24,8 @@ I/O related helpers.
 """
 
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from contextlib import contextmanager
 from sys import stdout
 

--- a/voitto/helpers/tracer.py
+++ b/voitto/helpers/tracer.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 import sys, traceback, inspect
 
 def traceit(frame, event, arg):
@@ -6,6 +9,6 @@ def traceit(frame, event, arg):
         filename, linenumber, funcname, text = stack[-1]
         args = inspect.getargvalues(frame)
         indent = len(stack) * " "
-        print "%s%s%s" % (indent, funcname, inspect.formatargvalues(*args))
+        print("%s%s%s" % (indent, funcname, inspect.formatargvalues(*args)))
 
     return traceit


### PR DESCRIPTION
You may be unaware that I used voitto as a Python 3 conversion example in "Python on a Nutshell."

I've finally got around to testing the resulting code under Python 3.7.1 and 2.7.15 and realised I at least owe you the courtesy of a pull request.

This change set should update the code so it's capable of running under either version. I haven't tested them recently, but I expect 3.5 and 3.6 will be fine. Didn't try for anything earlier.

Of course it's possible you no longer use the package, but I'm glad it was around when I needed to demonstrate porting techniques.